### PR TITLE
Fix medium buttons

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -44,7 +44,7 @@
         justify="center"
         class="px-1 mt-12"
       >
-        <v-window v-model="onboarding" reverse continuous show-arrows-on-hover>
+        <v-window v-model="onboarding" continuous show-arrows-on-hover>
           <v-window-item v-for="(slide, index) of articles" :key="index">
             <v-card
               align="left"
@@ -106,7 +106,7 @@ export default {
       return this.$i18n.locale
     },
     articles() {
-      return this.$store.state.medium.articles.data
+      return [...this.$store.state.medium.articles].reverse()
     },
   },
   mounted() {

--- a/store/medium.js
+++ b/store/medium.js
@@ -31,7 +31,7 @@ export const actions = {
   async getBlogPosts({ commit }) {
     try {
       const feed = await axios.get(FEED)
-      commit('SET_ARTICLES', feed)
+      commit('SET_ARTICLES', feed.data)
     } catch (e) {
       commit('SET_ARTICLES', fallback)
     }


### PR DESCRIPTION
Currently arrows under medium posts move the carousel in the wrong direction, and since articles are in reverse order in json, they'll start at the end and move backwards. This makes it start at the first and end on the last, and fixes the direction with the arrows.

Also in store, the fetch action sets the value in the state to the entire object returned by axios, not just object.data, so if it failed, the fallback wouldn't display because the getter in index.vue was fetching (...).data

So .data was added to feed in the action, then the getter reverses the order of the array so "reverse" could be removed from v-window.